### PR TITLE
[BUGFIX] Resolved jQuery race condition on WG Peers list

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
@@ -209,11 +209,15 @@ endif;
 
 <script type="text/javascript">
 //<![CDATA[
+events.push(function() {
+
 	$('.pubkey').click(function () {
 
 		navigator.clipboard.writeText($(this).attr('title'));
 
 	});
+
+});
 //]]>
 </script>
 


### PR DESCRIPTION
Spotted the error in console logs and copied events style from vpn_wg_peers_edit.php to resolve the jQuery copy code not loading on Peers List > Public key clicking