### PR TITLE
[FEATURE] Added primative widget for WireGuard

### DIFF
--- a/net/pfSense-pkg-WireGuard/Makefile
+++ b/net/pfSense-pkg-WireGuard/Makefile
@@ -29,6 +29,8 @@ do-install:
 	${MKDIR} ${STAGEDIR}${PREFIX}/pkg/wireguard
 
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/shortcuts
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/include
+	${MKDIR} ${STAGEDIR}${PREFIX}/www/widgets/widgets
 	${MKDIR} ${STAGEDIR}${PREFIX}/www/wg/js
 
 	${MKDIR} ${STAGEDIR}${DATADIR}
@@ -44,6 +46,12 @@ do-install:
 
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/shortcuts/pkg_wireguard.inc \
 		${STAGEDIR}${PREFIX}/www/shortcuts
+
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/widgets/include/wireguard.inc \
+		${STAGEDIR}${PREFIX}/www/widgets/include
+
+	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/widgets/widgets/wireguard.widget.php \
+		${STAGEDIR}${PREFIX}/www/widgets/widgets
 
 	${INSTALL_DATA} ${FILESDIR}${PREFIX}/www/wg/*.php \
 		${STAGEDIR}${PREFIX}/www/wg

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/include/wireguard.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/include/wireguard.inc
@@ -1,0 +1,27 @@
+<?php
+/*
+ * wireguard.inc
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2021 Vajonam
+ * Copyright (c) 2020 Ascrod
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+$wireguard_title = gettext("WireGuard");
+$wireguard_title_link = "/wg/status_wireguard.php";
+
+?>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/widgets/wireguard.widget.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/widgets/widgets/wireguard.widget.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * wireguard.widget.php
+ *
+ * part of pfSense (https://www.pfsense.org)
+ * Copyright (c) 2021 R. Christian McDonald (https://github.com/theonemcdonald)
+ * Copyright (c) 2021 Vajonam
+ * Copyright (c) 2020 Ascrod
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// pfSense includes
+require_once('guiconfig.inc');
+require_once('util.inc');
+require_once('/usr/local/www/widgets/include/wireguard.inc');
+
+// WireGuard includes
+require_once('wireguard/wg.inc');
+require_once('wireguard/wg_guiconfig.inc');
+require_once('wireguard/wg_service.inc');
+
+global $wgg;
+
+wg_globals();
+
+$a_devices = wg_get_status();
+
+if (empty($wgg['tunnels'])):
+
+print_info_box(gettext('No WireGuard tunnels have been configured.'), 'warning', null);
+
+elseif (empty($a_devices)):
+
+print_info_box(gettext('No WireGuard status information is available.'), 'warning', null);
+
+else:
+
+?>
+<div class="table-responsive panel-body">
+        <table class="table table-hover table-striped table-condensed" style="overflow-x: visible;">
+                <thead>
+                        <th><?=gettext('Tunnel')?></th>
+                        <th><?=gettext('Description')?></th>
+                        <th><?=gettext('# Peers')?></th>
+                        <th><?=gettext('Listen Port')?></th>
+                        <th><?=gettext('RX')?></th>
+                        <th><?=gettext('TX')?></th>
+                </thead>
+                <tbody>
+<?php
+
+	        foreach ($a_devices as $device_name => $device):
+?>
+                        <tr class="tunnel-entry">
+                                <td>
+                                        <?=wg_interface_status_icon($device['status'])?>
+                                        <a href="wg/vpn_wg_tunnels_edit.php?tun=<?=htmlspecialchars($device_name)?>"><?=htmlspecialchars($device_name)?>
+                                </td>
+                                <td><?=htmlspecialchars(wg_truncate_pretty($device['config']['descr'], 16))?></td>
+                                <td><?=count($device['peers'])?></td>
+                                <td><?=htmlspecialchars($device['listen_port'])?></td>
+                                <td><?=htmlspecialchars(format_bytes($device['transfer_rx']))?></td>
+                                <td><?=htmlspecialchars(format_bytes($device['transfer_tx']))?></td>
+			</tr>
+<?php
+	endforeach;
+
+?>
+	</tbody>
+
+</table>
+
+<?php
+
+endif;
+
+?>

--- a/net/pfSense-pkg-WireGuard/pkg-plist
+++ b/net/pfSense-pkg-WireGuard/pkg-plist
@@ -8,6 +8,8 @@ pkg/wireguard/wg_install.inc
 pkg/wireguard/wg_service.inc
 pkg/wireguard/wg_validate.inc
 www/shortcuts/pkg_wireguard.inc
+www/widgets/include/wireguard.inc
+www/widgets/widgets/wireguard.widget.php
 www/wg/js/WireGuardHelpers.js
 www/wg/status_wireguard.php
 www/wg/vpn_wg_peers.php


### PR DESCRIPTION
This commit brings along a very simple widget for the dashboard page
which displays all tunnels configured, their description, # of peers,
listening port, and traffic stats.

Will display info boxes if:
 - The service is not running
  - No tunnels are configured

  This widget is a copy-pasta from the wg status code, but slimmed down
  to not show peers and all the tunnel details.

  Discussions should be had around what fields people care about as it
  could easily be too "busy" for a widget.

  Also this can be a starting point for adding actions into the widget
  such as restarting tunnels, toggling peers, etc

Implements #119 