### PR TITLE
[FEATURE] Adding suggested ApprovedIP when adding peer

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
@@ -438,6 +438,8 @@ function wg_do_settings_post($post) {
 	$pconfig['interface_group']		= empty($post['interface_group']) ? 'all' : $post['interface_group'];
 	
 	$pconfig['hide_secrets']		= empty($post['hide_secrets']) ? 'no' : $post['hide_secrets'];
+	
+	$pconfig['suggest_next_approved_ip']		= empty($post['suggest_next_approved_ip']) ? 'no' : $post['suggest_next_approved_ip'];
 
 	$pconfig['hide_peers']			= empty($post['hide_peers']) ? 'no' : $post['hide_peers'];
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg.inc
@@ -439,7 +439,7 @@ function wg_do_settings_post($post) {
 	
 	$pconfig['hide_secrets']		= empty($post['hide_secrets']) ? 'no' : $post['hide_secrets'];
 	
-	$pconfig['suggest_next_approved_ip']		= empty($post['suggest_next_approved_ip']) ? 'no' : $post['suggest_next_approved_ip'];
+	$pconfig['suggest_next_approved_ip']	= empty($post['suggest_next_approved_ip']) ? 'no' : $post['suggest_next_approved_ip'];
 
 	$pconfig['hide_peers']			= empty($post['hide_peers']) ? 'no' : $post['hide_peers'];
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -927,6 +927,84 @@ function wg_tunnel_get_peers_config_keys($tunnel_name) {
 	return $keys;
 }
 
+/**
+ * Return the suggested next allowed IP for the next peer
+ */
+function wg_get_tunnel_next_allowed_ip($tunnel_name) {
+
+	$peers = wg_tunnel_get_peers_config($tunnel_name);
+	$tun_interface_addresses = pfSense_getall_interface_addresses($tunnel_name);
+
+	$interface_ipv4 = null;
+	$interface_ipv4_subnet = null;     // Lower interface IP for network, suggested must be >
+
+	$interface_ipv6 = null;
+
+	$highest_ipv4 = null;
+	$highest_ipv6 = null;
+
+	if (!empty($tun_interface_addresses)) {
+		// Looping interface IPs will cause last IPvX address to be the one we consider
+		foreach($tun_interface_addresses as $tia) {
+			$address = explode('/', $tia);
+
+			if (is_ipaddrv4($address[0])) {
+				$interface_ipv4 = ip2long($address[0]);
+				$interface_ipv4_mask = (int) $address[1];
+
+				$interface_ipv4_range = pow(2, (32 - $interface_ipv4_mask)) - 1;
+				$mask = long2ip(~$interface_ipv4_range);
+
+				$interface_ipv4_subnet = $interface_ipv4 & ip2long($mask);
+			} else {
+				$interface_ipv6 = $address[0];
+				$interface_ipv6_mask = $address[1];
+			}
+		}
+	}
+
+	$peer_ipv4_addresses = [];
+	$peer_ipv6_addresses = [];
+
+	// We have peers, so loop them, find the highest, plus one (if we have space)
+	foreach ($peers as $peer) {
+		foreach ($peer[1]['allowedips']['row'] as $peer_ip) {
+			if ($peer_ip['mask'] == '32') {
+				$peer_ipv4_addresses[] = ip2long($peer_ip['address']);
+			} else if ($peer_ip['mask'] == '128') {
+				$peer_ipv6_addresses[] = $peer_ip['address'];
+			}
+		}
+	}
+
+	// Loop over IPv4 addresses until we hit one not in use
+	if ($interface_ipv4 !== null) {
+		for ($possible_address = $interface_ipv4_subnet+1; $possible_address < ($interface_ipv4_subnet + ($interface_ipv4_range - 1)); $possible_address++) {
+			// Skip if this address is the same as the interface (could be first, could be last)
+			if ($possible_address == $interface_ipv4) {
+				continue;
+			}
+
+			// Skip if this address is taken by a peer
+			if (in_array($possible_address, $peer_ipv4_addresses)) {
+				continue;
+			}
+
+			// Now we have the first available peer address in the range
+			$highest_ipv4 = $possible_address;
+			break;
+		}
+	}
+
+	// Convert from long representation of IPv4 to string
+	if ($highest_ipv4 !== null) {
+		$highest_ipv4 = long2ip($highest_ipv4);
+	}
+
+	return [$highest_ipv4, $highest_ipv6];
+
+}
+
 /* 
  * Return WireGuard tunnel networks for a given address family
  */

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -928,20 +928,43 @@ function wg_tunnel_get_peers_config_keys($tunnel_name) {
 }
 
 /**
+ * Helper function used in wg_get_tunnel_next_allowed_ip below.
+ * Source: https://stackoverflow.com/a/16551680
+ */
+function _increment_ip($ip, $increment) {
+	$addr = inet_pton ( $ip );
+
+	for ( $i = strlen ( $addr ) - 1; $increment > 0 && $i >= 0; --$i ) {
+		$val = ord($addr[$i]) + $increment;
+		$increment = $val / 256;
+		$addr[$i] = chr($val % 256);
+	}
+
+	return inet_ntop ( $addr );
+}
+
+/**
  * Return the suggested next allowed IP for the next peer
  */
 function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 
 	$peers = wg_tunnel_get_peers_config($tunnel_name);
-	$tun_interface_addresses = pfSense_getall_interface_addresses($tunnel_name);
+
+	// pfSense interface addresses for assigned tunnels
+	if (is_wg_tunnel_assigned($tunnel_name)) {
+		$interface = wg_get_pfsense_interface_info($tunnel_name)['descr'];
+		$tun_interface_addresses = pfSense_getall_interface_addresses($interface);
+		exit(var_dump($interface, $tun_interface_addresses));
+	} else {	
+		$tun_interface_addresses = pfSense_getall_interface_addresses($tunnel_name);
+	}
 
 	$interface_ipv4 = null;
 	$interface_ipv4_subnet = null;     // Lower interface IP for network, suggested must be >
 
 	$interface_ipv6 = null;
 
-	$highest_ipv4 = null;
-	$highest_ipv6 = null;
+	var_dump($tun_interface_addresses, wg_get_pfsense_interface_info($tunnel_name));
 
 	if (!empty($tun_interface_addresses)) {
 		// Looping interface IPs will cause last IPvX address to be the one we consider
@@ -949,16 +972,17 @@ function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 			$address = explode('/', $tia);
 
 			if (is_ipaddrv4($address[0])) {
-				$interface_ipv4 = ip2long($address[0]);
+				$interface_ipv4 = $address[0];
 				$interface_ipv4_mask = (int) $address[1];
 
 				$interface_ipv4_range = pow(2, (32 - $interface_ipv4_mask)) - 1;
 				$mask = long2ip(~$interface_ipv4_range);
 
-				$interface_ipv4_subnet = $interface_ipv4 & ip2long($mask);
+				$interface_ipv4_subnet = long2ip( ip2long($interface_ipv4) & ip2long($mask) );
 			} else {
 				$interface_ipv6 = $address[0];
-				$interface_ipv6_mask = $address[1];
+				$interface_ipv6_mask = (int) $address[1];
+				$interface_ipv6_range = pow(2, (128 - $interface_ipv6_mask)) - 1;
 			}
 		}
 	}
@@ -966,42 +990,49 @@ function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 	$peer_ipv4_addresses = [];
 	$peer_ipv6_addresses = [];
 
-	// We have peers, so loop them, find the highest, plus one (if we have space)
+	// We have peers, so loop them all and store their IPs so we can check for existence
 	foreach ($peers as $peer) {
 		foreach ($peer[1]['allowedips']['row'] as $peer_ip) {
 			if ($peer_ip['mask'] == '32') {
-				$peer_ipv4_addresses[] = ip2long($peer_ip['address']);
+				$peer_ipv4_addresses[] = $peer_ip['address'];
 			} else if ($peer_ip['mask'] == '128') {
 				$peer_ipv6_addresses[] = $peer_ip['address'];
 			}
 		}
 	}
 
+	$suggested_ipv4 = null;
+	$suggested_ipv6 = null;
+
 	// Loop over IPv4 addresses until we hit one not in use
 	if ($interface_ipv4 !== null) {
-		for ($possible_address = $interface_ipv4_subnet+1; $possible_address < ($interface_ipv4_subnet + ($interface_ipv4_range - 1)); $possible_address++) {
-			// Skip if this address is the same as the interface (could be first, could be last)
-			if ($possible_address == $interface_ipv4) {
-				continue;
-			}
+		$suggested_ipv4 = _increment_ip($interface_ipv4_subnet, 1);
 
-			// Skip if this address is taken by a peer
-			if (in_array($possible_address, $peer_ipv4_addresses)) {
-				continue;
-			}
+		// Check if first IPv4 address is taken by interface, skip if is
+		if ($suggested_ipv4 == $interface_ipv4) {
+			$suggested_ipv4 = _increment_ip($suggested_ipv4, 1);
+		}
 
-			// Now we have the first available peer address in the range
-			$highest_ipv4 = $possible_address;
-			break;
+		// Now increment until we find the first unused IPv4 address
+		$i = 1;
+		while (in_array($suggested_ipv4, $peer_ipv4_addresses) && $i < ($interface_ipv4_range - 1)) {
+			$suggested_ipv4 = _increment_ip($suggested_ipv4, 1);
+			$i++;
 		}
 	}
 
-	// Convert from long representation of IPv4 to string
-	if ($highest_ipv4 !== null) {
-		$highest_ipv4 = long2ip($highest_ipv4);
+	// Loop over IPv6 addresses until we hit one not in use
+	if ($interface_ipv6 !== null) {
+		$suggested_ipv6 = _increment_ip($interface_ipv6, 1);
+
+		$i = 1;
+		while (in_array($suggested_ipv6, $peer_ipv6_addresses) && $i < ($interface_ipv6_range - 1)) {
+			$suggested_ipv6 = _increment_ip($suggested_ipv6, 1);
+			$i++;
+		}
 	}
 
-	return [$highest_ipv4, $highest_ipv6];
+	return [$suggested_ipv4, $suggested_ipv6];
 
 }
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -948,44 +948,61 @@ function _increment_ip($ip, $increment) {
  */
 function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 
-	$peers = wg_tunnel_get_peers_config($tunnel_name);
+	$interface_ipv4 = null;
+	$interface_ipv4_mask = null;
+
+	$interface_ipv6 = null;
+	$interface_ipv6_mask = null;
 
 	// pfSense interface addresses for assigned tunnels
 	if (is_wg_tunnel_assigned($tunnel_name)) {
-		$interface = wg_get_pfsense_interface_info($tunnel_name)['descr'];
-		$tun_interface_addresses = pfSense_getall_interface_addresses($interface);
-		exit(var_dump($interface, $tun_interface_addresses));
-	} else {	
+
+		$interface = wg_get_pfsense_interface_info($tunnel_name)['name'];
+		$if_details = get_interface_info($interface);
+
+		if (!empty($if_details['ipaddr'])) {
+			$interface_ipv4 = $if_details['ipaddr'];
+			// ipv4 subnet is actually full 255.255.255.0, not 24 or example
+			$long = ip2long($if_details['subnet']);
+			$base = ip2long('255.255.255.255');
+			$interface_ipv4_mask = 32 - log(($long ^ $base)+1, 2);
+		}
+
+		if (!empty($if_details['ipaddrv6'])) {
+			$interface_ipv6 = $if_details['ipaddrv6'];
+			$interface_ipv6_mask = (int) $if_details['subnetv6'];
+		}
+
+	} else {
+
 		$tun_interface_addresses = pfSense_getall_interface_addresses($tunnel_name);
-	}
 
-	$interface_ipv4 = null;
-	$interface_ipv4_subnet = null;     // Lower interface IP for network, suggested must be >
+		if (!empty($tun_interface_addresses)) {
+			// Looping interface IPs will cause last IPvX address to be the one we consider
+			foreach($tun_interface_addresses as $tia) {
+				$address = explode('/', $tia);
 
-	$interface_ipv6 = null;
-
-	var_dump($tun_interface_addresses, wg_get_pfsense_interface_info($tunnel_name));
-
-	if (!empty($tun_interface_addresses)) {
-		// Looping interface IPs will cause last IPvX address to be the one we consider
-		foreach($tun_interface_addresses as $tia) {
-			$address = explode('/', $tia);
-
-			if (is_ipaddrv4($address[0])) {
-				$interface_ipv4 = $address[0];
-				$interface_ipv4_mask = (int) $address[1];
-
-				$interface_ipv4_range = pow(2, (32 - $interface_ipv4_mask)) - 1;
-				$mask = long2ip(~$interface_ipv4_range);
-
-				$interface_ipv4_subnet = long2ip( ip2long($interface_ipv4) & ip2long($mask) );
-			} else {
-				$interface_ipv6 = $address[0];
-				$interface_ipv6_mask = (int) $address[1];
-				$interface_ipv6_range = pow(2, (128 - $interface_ipv6_mask)) - 1;
+				if (is_ipaddrv4($address[0])) {
+					$interface_ipv4 = $address[0];
+					$interface_ipv4_mask = (int) $address[1];
+				} else {
+					$interface_ipv6 = $address[0];
+					$interface_ipv6_mask = (int) $address[1];
+				}
 			}
 		}
+
 	}
+
+	$interface_ipv4_subnet = null;
+
+	if ($interface_ipv4 !== null) {
+		$interface_ipv4_range = pow(2, (32 - $interface_ipv4_mask)) - 1;
+		$mask = long2ip(~$interface_ipv4_range);
+		$interface_ipv4_subnet = long2ip( ip2long($interface_ipv4) & ip2long($mask) );
+	}
+
+	$peers = wg_tunnel_get_peers_config($tunnel_name);
 
 	$peer_ipv4_addresses = [];
 	$peer_ipv6_addresses = [];
@@ -1005,7 +1022,7 @@ function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 	$suggested_ipv6 = null;
 
 	// Loop over IPv4 addresses until we hit one not in use
-	if ($interface_ipv4 !== null) {
+	if ($interface_ipv4_subnet !== null) {
 		$suggested_ipv4 = _increment_ip($interface_ipv4_subnet, 1);
 
 		// Check if first IPv4 address is taken by interface, skip if is
@@ -1024,6 +1041,8 @@ function wg_get_tunnel_next_allowed_ip($tunnel_name) {
 	// Loop over IPv6 addresses until we hit one not in use
 	if ($interface_ipv6 !== null) {
 		$suggested_ipv6 = _increment_ip($interface_ipv6, 1);
+
+		$interface_ipv6_range = pow(2, (128 - $interface_ipv6_mask)) - 1;
 
 		$i = 1;
 		while (in_array($suggested_ipv6, $peer_ipv6_addresses) && $i < ($interface_ipv6_range - 1)) {

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_install.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_install.inc
@@ -162,6 +162,8 @@ function wg_defaults_install() {
 
 	$wgg['config']['hide_peers'] 			= isset($wgg['config']['hide_peers']) ? $wgg['config']['hide_peers'] : 'yes';
 	
+	$wgg['config']['suggest_next_approved_ip']	= isset($wgg['config']['suggest_next_approved_ip']) ? $wgg['config']['suggest_next_approved_ip'] : 'yes';
+	
 	wg_write_config('Applied package default settings as necessary.', false);
 }
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -265,8 +265,6 @@ $section->addInput(new Form_StaticText(
 // Init the addresses array if necessary
 if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['row'])) {
 
-	wg_init_config_arr($pconfig, array('allowedips', 'row', 0));
-
 	$user_wants_suggestion = isset($wgg['config']['suggest_next_approved_ip']) && $wgg['config']['suggest_next_approved_ip'] == 'yes';
 
 	// Suggest the next available IP address (if applicable)
@@ -274,22 +272,24 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 		$suggested_next_ips = wg_get_tunnel_next_allowed_ip($pconfig['tun']);
 
 		if (!empty($suggested_next_ips)) {
-			$ipv4_address = $suggested_next_ips[0];
+			$rows = 0;
 
+			$ipv4_address = $suggested_next_ips[0];
 			if ($ipv4_address !== null) {
-				$pconfig['allowedips']['row'][0]['address'] = $ipv4_address;
-				$pconfig['allowedips']['row'][0]['mask'] = '32';
-				$pconfig['allowedips']['row'][0]['descr'] = 'Suggested next available IPv4';
+				wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
+				$pconfig['allowedips']['row'][$rows]['address'] = $ipv4_address;
+				$pconfig['allowedips']['row'][$rows]['mask'] = '32';
+				$pconfig['allowedips']['row'][$rows]['descr'] = 'Suggested next available IPv4';
+				$rows++;
 			}
 
 			$ipv6_address = $suggested_next_ips[1];
 
 			if ($ipv6_address !== null) {
-				wg_init_config_arr($pconfig, array('allowedips', 'row', 1));
-
-				$pconfig['allowedips']['row'][1]['address'] = $ipv6_address;
-				$pconfig['allowedips']['row'][1]['mask'] = '128';
-				$pconfig['allowedips']['row'][1]['descr'] = 'Suggested next available IPv6';
+				wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
+				$pconfig['allowedips']['row'][$rows]['address'] = $ipv6_address;
+				$pconfig['allowedips']['row'][$rows]['mask'] = '128';
+				$pconfig['allowedips']['row'][$rows]['descr'] = 'Suggested next available IPv6';
 			}
 		}
 	}

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -266,9 +266,39 @@ $section->addInput(new Form_StaticText(
 if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['row'])) {
 
 	wg_init_config_arr($pconfig, array('allowedips', 'row', 0));
-	
-	// Hack to ensure empty lists default to /128 mask
-	$pconfig['allowedips']['row'][0]['mask'] = '128';
+
+	$user_wants_suggestion = isset($wgg['config']['suggest_next_approved_ip']) && $wgg['config']['suggest_next_approved_ip'] == 'yes';
+
+	// Suggest the next available IP address (if applicable)
+	if ($user_wants_suggestion && !empty($pconfig['tun']) && $pconfig['tun'] != 'unassigned') {
+		$suggested_next_ips = wg_get_tunnel_next_allowed_ip($pconfig['tun']);
+
+		if (!empty($suggested_next_ips)) {
+			$ipv4_address = $suggested_next_ips[0];
+
+			if ($ipv4_address !== null) {
+				$pconfig['allowedips']['row'][0]['address'] = $ipv4_address;
+				$pconfig['allowedips']['row'][0]['mask'] = '32';
+				$pconfig['allowedips']['row'][0]['descr'] = 'Suggested next available IPv4';
+			}
+
+			$ipv6_address = $suggested_next_ips[1];
+
+			if ($ipv6_address !== null) {
+				wg_init_config_arr($pconfig, array('allowedips', 'row', 1));
+
+				$pconfig['allowedips']['row'][1]['address'] = $ipv6_address;
+				$pconfig['allowedips']['row'][1]['mask'] = '128';
+				$pconfig['allowedips']['row'][1]['descr'] = 'Suggested next available IPv6';
+			}
+		}
+	}
+
+	// Default if we don't set it above
+	if (empty($pconfig['allowedips']['row'][0])) {
+		// Hack to ensure empty lists default to /128 mask
+		$pconfig['allowedips']['row'][0]['mask'] = '128';
+	}
 	
 }
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -284,7 +284,6 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 			}
 
 			$ipv6_address = $suggested_next_ips[1];
-
 			if ($ipv6_address !== null) {
 				wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
 				$pconfig['allowedips']['row'][$rows]['address'] = $ipv6_address;
@@ -295,7 +294,9 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 	}
 
 	// Default if we don't set it above
-	if (empty($pconfig['allowedips']['row'][0])) {
+	if (empty($pconfig['allowedips']['row'])) {
+		wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
+
 		// Hack to ensure empty lists default to /128 mask
 		$pconfig['allowedips']['row'][0]['mask'] = '128';
 	}

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -295,7 +295,7 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 
 	// Default if we don't set it above
 	if (empty($pconfig['allowedips']['row'])) {
-		wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
+		wg_init_config_arr($pconfig, array('allowedips', 'row', 0));
 
 		// Hack to ensure empty lists default to /128 mask
 		$pconfig['allowedips']['row'][0]['mask'] = '128';

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -279,7 +279,7 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 				wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
 				$pconfig['allowedips']['row'][$rows]['address'] = $ipv4_address;
 				$pconfig['allowedips']['row'][$rows]['mask'] = '32';
-				$pconfig['allowedips']['row'][$rows]['descr'] = 'Suggested next available IPv4';
+				$pconfig['allowedips']['row'][$rows]['descr'] = gettext('Suggested next available IPv4');
 				$rows++;
 			}
 
@@ -288,7 +288,7 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 				wg_init_config_arr($pconfig, array('allowedips', 'row', $rows));
 				$pconfig['allowedips']['row'][$rows]['address'] = $ipv6_address;
 				$pconfig['allowedips']['row'][$rows]['mask'] = '128';
-				$pconfig['allowedips']['row'][$rows]['descr'] = 'Suggested next available IPv6';
+				$pconfig['allowedips']['row'][$rows]['descr'] = gettext('Suggested next available IPv6');
 			}
 		}
 	}

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -268,7 +268,7 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 	$user_wants_suggestion = isset($wgg['config']['suggest_next_approved_ip']) && $wgg['config']['suggest_next_approved_ip'] == 'yes';
 
 	// Suggest the next available IP address (if applicable)
-	if ($user_wants_suggestion && !empty($pconfig['tun']) && is_wg_tunnel_assigned($pconfig['tun'])) {
+	if ($user_wants_suggestion && !empty($pconfig['tun']) && $pconfig['tun'] != 'unassigned') {
 		$suggested_next_ips = wg_get_tunnel_next_allowed_ip($pconfig['tun']);
 
 		if (!empty($suggested_next_ips)) {

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers_edit.php
@@ -268,7 +268,7 @@ if (!is_array($pconfig['allowedips']['row']) || empty($pconfig['allowedips']['ro
 	$user_wants_suggestion = isset($wgg['config']['suggest_next_approved_ip']) && $wgg['config']['suggest_next_approved_ip'] == 'yes';
 
 	// Suggest the next available IP address (if applicable)
-	if ($user_wants_suggestion && !empty($pconfig['tun']) && $pconfig['tun'] != 'unassigned') {
+	if ($user_wants_suggestion && !empty($pconfig['tun']) && is_wg_tunnel_assigned($pconfig['tun'])) {
 		$suggested_next_ips = wg_get_tunnel_next_allowed_ip($pconfig['tun']);
 
 		if (!empty($suggested_next_ips)) {

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
@@ -243,7 +243,7 @@ $section->addInput(new Form_Checkbox(
     	gettext('Enable'),
     	$pconfig['suggest_next_approved_ip'] == 'yes'
 ))->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
-		{$s(gettext("With 'Suggest Next Approvied IP' enabled, when creating a new Peer for a Tunnel it will pre-populate the Allowed IP with the next available IP address."))}");
+		{$s(gettext("With 'Suggest Next Approved IP' enabled, when creating a new Peer for a Tunnel it will pre-populate the Allowed IP with the next available IP address."))}");
 
 $form->add($section);
 

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_settings.php
@@ -237,6 +237,14 @@ $section->addInput(new Form_Checkbox(
 ))->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
 		{$s(gettext("With 'Hide Peers' enabled (default), all peers for all tunnels will initially be hidden on the status page."))}");
 		
+$section->addInput(new Form_Checkbox(
+	'suggest_next_approved_ip',
+	gettext('Suggest Next Approved IP'),
+    	gettext('Enable'),
+    	$pconfig['suggest_next_approved_ip'] == 'yes'
+))->setHelp("<span class=\"text-danger\">{$s(gettext('Note:'))} </span>
+		{$s(gettext("With 'Suggest Next Approvied IP' enabled, when creating a new Peer for a Tunnel it will pre-populate the Allowed IP with the next available IP address."))}");
+
 $form->add($section);
 
 $form->addGlobal(new Form_Input(


### PR DESCRIPTION
This PR should resolve [RM ticket 11588](https://redmine.pfsense.org/issues/11588).

It adds a new setting option `Suggest Next Approved IP`.

If the above setting is enabled, when a user creates a new peer (for an existing tunnel atm, need to look at breaking out to JS so we can pick it up when the user navigates to Add New Peer page without pre-selecting a tunnel) it will work out what the next available IP address is.

It does this by working out the subnet value, broadcast value, and any existing peers. Once we have these values we can iterate from the subnet + 1 up until broadcast - 1, the first available IP address is "taken".

So we have the following examples of expected behaviour:

- Tunnel's assigned interface has static IPv4 address of `192.168.100.1` with cidr range of `/24`
  - Peers with the IP addresses: `192.168.100.2, 192.168.100.3, 192.168.100.4, 192.168.100.6, 192.168.100.7`
  - With the above setting enabled, when click the "Add new peer for this tunnel" button, it will pre-fill the ApprovedIP list with the address `192.168.100.5/32` given it's available. Doing this a second time (if we create `.100.5`) will result in the IP address `192.168.100.8/32` being suggested

- Tunnel's WG specified IP address of `192.168.150.254/24`
  - Suggests IP address `192.168.150.1/32`

In this PR I'm iterating from subnet to broadcast as we can't assume the interface address is always lowest (`.1/24` for example) as it could also be highest (`.254/24` for example).

This is currently a work in progress and should not be deployed.