### PR TITLE
[BUGFIX] Resolves pages flickering & public key cursor on hover

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
@@ -138,7 +138,7 @@ if (!empty($a_devices)):
 					<td><?=htmlspecialchars(format_bytes($device['transfer_rx']))?></td>
 					<td><?=htmlspecialchars(format_bytes($device['transfer_tx']))?></td>
 				</tr>
-				<tr class="peer-entries">
+				<tr style="display: none;" class="peer-entries">
 					<td colspan="9">
 						<table class="table table-hover table-condensed">
 							<thead>
@@ -250,8 +250,6 @@ endif;
 //<![CDATA[
 events.push(function() {
 	var peershidden = true;
-
-	hideClass('peer-entries', peershidden);
 
 	// Toggle peer visibility
 	$('#showpeers').click(function () {

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_peers.php
@@ -169,7 +169,7 @@ if (is_array($wgg['peers']) && count($wgg['peers']) > 0):
 ?>
 					<tr ondblclick="document.location='<?="vpn_wg_peers_edit.php?peer={$peer_idx}"?>';" class="<?=wg_peer_status_class($peer)?>">
 						<td><?=htmlspecialchars(wg_truncate_pretty($peer['descr'], 16))?></td>
-						<td class="pubkey" title="<?=htmlspecialchars($peer['publickey'])?>">
+						<td style="cursor: pointer;" class="pubkey" title="<?=htmlspecialchars($peer['publickey'])?>">
 							<?=htmlspecialchars(wg_truncate_pretty($peer['publickey'], 16))?>
 						</td>
 						<td><?=htmlspecialchars($peer['tun'])?></td>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
@@ -185,7 +185,7 @@ if (is_array($wgg['tunnels']) && count($wgg['tunnels']) > 0):
 						<td style="display: none;" class="peer-entries"><?=gettext('Interface')?></td>
 						<td><?=htmlspecialchars($tunnel['name'])?></td>
 						<td><?=htmlspecialchars($tunnel['descr'])?></td>
-						<td style="cursor: pointer;" class="pubkey" title="Click to copy: <?=htmlspecialchars($tunnel['publickey'])?>">
+						<td style="cursor: pointer;" class="pubkey" title="<?=htmlspecialchars($tunnel['publickey'])?>">
 							<?=htmlspecialchars(wg_truncate_pretty($tunnel['publickey'], 16))?>
 						</td>
 						<td><?=wg_generate_tunnel_address_popover_link($tunnel['name'])?></td>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
@@ -163,7 +163,7 @@ display_top_tabs($tab_array);
 			<table class="table table-hover table-striped table-condensed">
 				<thead>
 					<tr>
-						<th class="peer-entries"></th>
+						<th style="display: none;" class="peer-entries"></th>
 						<th><?=gettext("Name")?></th>
 						<th><?=gettext("Description")?></th>
 						<th><?=gettext("Public Key")?></th>
@@ -182,10 +182,10 @@ if (is_array($wgg['tunnels']) && count($wgg['tunnels']) > 0):
 			$peers = wg_tunnel_get_peers_config($tunnel['name']);
 ?>
 					<tr ondblclick="document.location='vpn_wg_tunnels_edit.php?tun=<?=$tunnel['name']?>';" class="<?=wg_tunnel_status_class($tunnel)?>">
-						<td class="peer-entries"><?=gettext('Interface')?></td>
+						<td style="display: none;" class="peer-entries"><?=gettext('Interface')?></td>
 						<td><?=htmlspecialchars($tunnel['name'])?></td>
 						<td><?=htmlspecialchars($tunnel['descr'])?></td>
-						<td class="pubkey" title="<?=htmlspecialchars($tunnel['publickey'])?>">
+						<td style="cursor: pointer;" class="pubkey" title="Click to copy: <?=htmlspecialchars($tunnel['publickey'])?>">
 							<?=htmlspecialchars(wg_truncate_pretty($tunnel['publickey'], 16))?>
 						</td>
 						<td><?=wg_generate_tunnel_address_popover_link($tunnel['name'])?></td>
@@ -201,7 +201,7 @@ if (is_array($wgg['tunnels']) && count($wgg['tunnels']) > 0):
 						</td>
 					</tr>
 
-					<tr class="peer-entries peerbg_color">
+					<tr style="display: none;" class="peer-entries peerbg_color">
 						<td><?=gettext("Peers")?></td>
 <?php
 			if (count($peers) > 0):
@@ -277,8 +277,6 @@ events.push(function() {
 	var peershidden = true;
 
 	var keyshidden = true;
-
-	hideClass('peer-entries', peershidden);
 
 	// Toggle peer visibility
 	$('#showpeers').click(function () {


### PR DESCRIPTION
Tunnel list page featuring the tunnel's public key in a table and the Peers list page featuring the peer's public key both have JS events alowing the user to click on them to copy their value, however I only kno about this due to looking at the source code and console errors (previous PR fixed); Having the cursor set to pointer will at least show the user it's clickable, and hopefully they find out it copies the value. Being able to provide a toast or similar may be more useful for UX feedback.

When loading tunnels page or status page, the DOM will flicker as divs are loaded with a display but JS then hides them when loaded.

This PR:
- Resolves flickering on tunnel list page, and settings page
- Ensures `cursor: pointer` is set on the Tunnel list page and the peers lis page for the Tunne / Peer public key field which is truncated