### PR TITLE
BUGFIX Resolves treegrid flickering

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/status_wireguard.php
@@ -99,6 +99,10 @@ $a_devices = wg_get_status();
 
 ?>
 
+<?php if (wg_status_peers_hidden()) { ?>
+<style> tr[class^='treegrid-parent-'] { display: none; } </style>
+<?php } ?>
+
 <div class="panel panel-default">
 	<div class="panel-heading">
 		<h2 class="panel-title"><?=gettext('WireGuard Status')?></h2>

--- a/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/www/wg/vpn_wg_tunnels.php
@@ -156,6 +156,8 @@ display_top_tabs($tab_array);
 
 ?>
 
+<style> tr[class^='treegrid-parent-'] { display: none; } </style>
+
 <form name="mainform" method="post">
 	<div class="panel panel-default">
 		<div class="panel-heading"><h2 class="panel-title"><?=gettext('WireGuard Tunnels')?></h2></div>


### PR DESCRIPTION
Inline with my previous PR of using CSS to display:none the items we didn't want to see on page load (tunnels list always and status page only if use has unchecked `hide peers` checkbox).

I still feel leacing it to the JS to hide the rows leads to poor UX with flickering