### PR TITLE
[FEATURE] New peer validation to prevent duplicate default routes

### DIFF
--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -760,7 +760,7 @@ function wg_peer_is_default_route($peer) {
 	// TODO: Unassigned tunnel check?
 
 	if (!empty($peer['allowedips']['row']) && is_array($peer['allowedips']['row'])) {
-	        foreach ((array) $peer['allowedips']['row'] as $row) {
+		foreach ((array) $peer['allowedips']['row'] as $row) {
 			# Only interested in default routes using masks of /0
 			if ($row['mask'] != '0') {
 				continue;
@@ -890,7 +890,7 @@ function wg_tunnel_has_default_route_peer($tunnel_name, $ignore_peer_idx) {
 	$default_ipv6 = false;
 
 	foreach (wg_tunnel_get_peers_config($tunnel_name) as [$peer_idx, $peer, $is_new]) {
-                if ($peer_idx != $ignore_peer_idx) {
+		if ($peer_idx != $ignore_peer_idx) {
 			[$peer_default_ipv4, $peer_default_ipv6] = wg_peer_is_default_route($peer);
 
 			if ($peer_default_ipv4) {
@@ -900,13 +900,13 @@ function wg_tunnel_has_default_route_peer($tunnel_name, $ignore_peer_idx) {
 			if ($peer_default_ipv6) {
 				$default_ipv6 = true;
 			}
-                }
+		}
 
 		# Check if we can stop early
 		if ($default_ipv4 && $default_ipv6) {
 			break;
 		}
-        }
+	}
 
 	return [$default_ipv4, $default_ipv6];
 }

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_api.inc
@@ -751,6 +751,39 @@ function wg_peer_is_enabled($tunnel, $public_key) {
 }
 
 /*
+ * Check if the given peer has any allowed ips indicating it's the default route it's tunnel
+ */
+function wg_peer_is_default_route($peer) {
+	$default_ipv4 = false;
+	$default_ipv6 = false;
+
+	// TODO: Unassigned tunnel check?
+
+	if (!empty($peer['allowedips']['row']) && is_array($peer['allowedips']['row'])) {
+	        foreach ((array) $peer['allowedips']['row'] as $row) {
+			# Only interested in default routes using masks of /0
+			if ($row['mask'] != '0') {
+				continue;
+			}
+
+			if (is_ipaddrv4($row['address']) && $row['address'] == '0.0.0.0') {
+				$default_ipv4 = true;
+			# TODO: Check for compressed IPv6 addresses? Could it be bypassed with 0::/0, or 0:0000:0::/0 etc
+			} else if (is_ipaddrv6($row['address']) && $row['address'] == '::') {
+				$default_ipv6 = true;
+			}
+
+			# Check if we can break out early
+			if ($default_ipv4 && $default_ipv6) {
+				break;
+			}
+		}
+	}
+
+	return [$default_ipv4, $default_ipv6];
+}
+
+/*
  * Check if a given WireGuard peer is valid
  */
 function wg_peer_is_valid($tunnel_name, $public_key, $running_state = false) {
@@ -847,6 +880,35 @@ function wg_tunnel_get_config($tun_idx, $return_empty = false) {
 	wg_init_config_arr($tunnel, array('addresses', 'row'));
 
 	return ($valid || $return_empty) ? array($tun_idx, $tunnel, $is_new) : false;
+}
+
+/*
+ * Return bools indicating if the tunnel referenced has any peers with default IPv4 or IPv6 routes
+ */
+function wg_tunnel_has_default_route_peer($tunnel_name, $ignore_peer_idx) {
+	$default_ipv4 = false;
+	$default_ipv6 = false;
+
+	foreach (wg_tunnel_get_peers_config($tunnel_name) as [$peer_idx, $peer, $is_new]) {
+                if ($peer_idx != $ignore_peer_idx) {
+			[$peer_default_ipv4, $peer_default_ipv6] = wg_peer_is_default_route($peer);
+
+			if ($peer_default_ipv4) {
+				$default_ipv4 = true;
+			}
+
+			if ($peer_default_ipv6) {
+				$default_ipv6 = true;
+			}
+                }
+
+		# Check if we can stop early
+		if ($default_ipv4 && $default_ipv6) {
+			break;
+		}
+        }
+
+	return [$default_ipv4, $default_ipv6];
 }
 
 function wg_peer_get_config($peer_idx, $return_empty = false) {

--- a/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
+++ b/net/pfSense-pkg-WireGuard/files/usr/local/pkg/wireguard/includes/wg_validate.inc
@@ -200,12 +200,24 @@ function wg_validate_peer_post($pconfig, $posted_peer_idx) {
 		$input_errors[] = "The pre-shared key ({$pconfig['presharedkey']}) is not a valid WireGuard pre-shared key.";
 	}
 
+	// We don't want duplicate default routes, but re-saving is okay...
+	[$ipv4_default_route_exists, $ipv6_default_route_exists] = wg_tunnel_has_default_route_peer($pconfig['tun'], $posted_peer_idx);
+
 	// Check allowed ips
 	if (!empty($pconfig['allowedips']['row']) && is_array($pconfig['allowedips']['row'])) {
 		foreach ((array) $pconfig['allowedips']['row'] as $row) {
 			$row['address'] = trim($row['address']);
 
 			$tmp_subnet = "{$row['address']}/{$row['mask']}";
+
+			if ($tmp_subnet == '0.0.0.0/0' && $ipv4_default_route_exists) {
+				$input_errors[] = "Tunnel can only have one default IPv4 route";
+			}
+
+			# TODO: Concern over IPv6 compression bypassing
+			if ($tmp_subnet == '::/0' && $ipv6_default_route_exists) {
+				$input_errors[] = "Tunnel can only have one default IPv6 route";
+			}
 
 			if (!empty($row['address']) && !is_subnet($tmp_subnet)) {
 				$input_errors[] = "Address {$tmp_subnet} is not a valid IPv4 or IPv6 CIDR subnet address.";


### PR DESCRIPTION
Resolves RM ticket [11465](https://redmine.pfsense.org/issues/11465).

This PR will add validation checks and user feedback if they attempt to add a new peer to a tunnel which already has another peer with either `0.0.0.0/0` or `::/0` (or both) default routes specified in the allowed ips list, which is not valid.

Current plugin validation does not catch this issue.

I do have a query regarding a difference between this plugin and the original WG implementation; the ticket lists a bunch of test scenarios:
```
PASS    Create a tunnel with one peer that has Allowed IPs empty -- should succeed

PASS    Create a tunnel with the first peer Allowed IPs set to "10.0.0.0/24" or equivalent non-default network
PASS    Add a peer to this tunnel with Allowed IPs set to "0.0.0.0/0" -- should succeed (first IPv4 default for this tunnel)
PASS    Add a peer to this tunnel with Allowed IPs set to "::/0" -- should succeed (first IPv6 default for this tunnel)
FAIL    Add a peer to this tunnel with Allowed IPs empty -- should fail (additional attempt at IPv4 and IPv6 default)
PASS    Add a peer to this tunnel with Allowed IPs set to "0.0.0.0/0" -- should fail
PASS    Add a peer to this tunnel with Allowed IPs set to "::/0" -- should fail

    Create a tunnel with the first peer Allowed IPs set to "10.0.0.0/24" or equivalent non-default network -- should succeed
    Add a peer to this tunnel with Allowed IPs empty -- should succeed (IPv4 and IPv6 default for this tunnel)
    Add a peer to this tunnel with Allowed IPs empty -- should fail
    Add a peer to this tunnel with Allowed IPs set to "::/0" -- should fail
    Add a peer to this tunnel with Allowed IPs set to "0.0.0.0/0" -- should fail

    Create a tunnel with the first peer Allowed IPs empty -- should succeed
    Add a peer to this tunnel with Allowed IPs set to "::/0" -- should fail
    Add a peer to this tunnel with Allowed IPs set to "0.0.0.0/0" -- should fail
    Add a peer to this tunnel with Allowed IPs set to "10.0.1.0/24" -- should succeed
    Add a peer to this tunnel with Allowed IPs set to "fc07:1::0/64" -- should succeed

    Create a tunnel with the first peer Allowed IPs set to "10.5.0.0/24" or equivalent non-default network -- should succeed
    Add a peer to this tunnel with Allowed IPs set to "10.5.1.0/24" -- should succeed
    Add a peer to this tunnel with Allowed IPs set to "10.5.2.0/24" -- should succeed
```

However does this plugin actually take an allowed IPs list of `(none)` to equate the default route for both IPv4 and IPv6 for this tunnel? I've a hunch it doesn't and because it doesn't the provided validation logic will not catch this scenario.

It will prevent any attempt to add a new peer to a tunnel which already has a default route (checks 0.0.0.0/0 or v4 and ::/0 for v6); which leads onto my section question, which is more generic.

Does this wireguard plugin (or anything in pSense more generally) validate IPv6 `::/0` addresses for compression? As currently a user could "bypass" this new IPv6 default route validation by providing any of the following values instead:
- `0::/0`
- `0:0000:0::/0`
- `::0/0`
- etc

But would WG / any other pfSense component actually accept these variants of the same address for routing purposes?